### PR TITLE
Python cross-compiling script and ABI3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,14 @@
 
 ## Unreleased
 
+### Changed
+
+* Publish python wheels with cp39-abi3 (https://github.com/rust-nostr/nostr-sdk-ffi/pull/7)
+
 ### Added
 
-* Add support for event streaming (https://github.com/rust-nostr/nostr-sdk-ffi/pull/6) 
+* Add support for event streaming (https://github.com/rust-nostr/nostr-sdk-ffi/pull/6)
+* Add `i686-unknown-linux-gnu`, `i686-pc-windows-msvc` and `aarch64-pc-windows-msvc` support for Python Wheels (https://github.com/rust-nostr/nostr-sdk-ffi/pull/7)
 
 ## v0.41.0 - 2025/04/15
 
@@ -41,7 +46,7 @@
 
 ### Added
 
-* Add support for `i686-pc-windows-msvc` and `aarch64-pc-windows-msv`
+* Add support for `i686-pc-windows-msvc` and `aarch64-pc-windows-msvc`
 * Add support to `i686-unknown-linux-gnu`
 * Expose `Relay::ban`
 * Derive `Hash` and `Display` traits where possible

--- a/justfile
+++ b/justfile
@@ -47,6 +47,10 @@ aar:
 jar:
     @cd jvm && bash assemble.sh
 
+# Assemble the python wheels
+py:
+    @cd python && bash assemble.sh
+
 # Assemble the C# package
 csharp:
     @cd csharp && bash assemble.sh
@@ -60,6 +64,11 @@ publish-aar: aar
 [confirm]
 publish-jar: jar
 	cd jvm && ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+
+# Publish Wheels
+[confirm]
+publish-py: py
+    cd python && twine upload dist/*
 
 # Compile and build Swift Package
 [macos]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.9-slim
+
+# Set up working directory
+WORKDIR /build
+
+# Create directories for mounting volumes
+RUN mkdir -p python binding binaries dist
+
+# Copy source
+COPY src/nostr-sdk/__init__.py python/src/nostr-sdk/
+COPY LICENSE python/
+COPY MANIFEST.in python/
+COPY pyproject.toml python/
+COPY README.md python/
+COPY requirements.txt python/
+COPY setup.py python/
+
+# Copy the build script
+COPY --chown=1000:1000 buildwheel.sh .
+RUN chmod +x buildwheel.sh
+
+# Install Python build tools
+RUN pip install -r python/requirements.txt
+
+# Update permissions
+RUN chown -R 1000:1000 /build
+RUN chmod -R 777 /build
+
+# Change user
+USER 1000
+
+# Set the entrypoint to our build script
+ENTRYPOINT ["/build/buildwheel.sh"]

--- a/python/assemble.sh
+++ b/python/assemble.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIST_DIR="${SCRIPT_DIR}/dist"
+SRC_DIR="${SCRIPT_DIR}/src/nostr-sdk"
+FFI_DIR="${SCRIPT_DIR}/../ffi"
+
+# Clean
+rm -rf "${DIST_DIR}"
+rm -rf "${SRC_DIR}/*.so"
+rm -rf "${SRC_DIR}/nostr_sdk.py"
+
+# Make dir
+mkdir -p "${DIST_DIR}"
+
+# Build docker image
+docker build -t wheel-builder "${SCRIPT_DIR}"
+
+# Generate bindings
+cargo run -p nostr-sdk-ffi --features uniffi-cli --bin uniffi-bindgen generate --library "${FFI_DIR}/apple/macos/x86_64/libnostr_sdk_ffi.dylib" --language python --no-format -o "${SRC_DIR}"
+
+# Build linux wheels
+docker run --rm -v "${FFI_DIR}/linux/x86/:/build/binaries" -v "${SRC_DIR}:/build/binding" -v "$(pwd)/dist:/build/dist" -e PLAT_NAME="manylinux_2_17_i686" wheel-builder
+docker run --rm -v "${FFI_DIR}/linux/x86_64/:/build/binaries" -v "${SRC_DIR}:/build/binding" -v "$(pwd)/dist:/build/dist" -e PLAT_NAME="manylinux_2_17_x86_64" wheel-builder
+docker run --rm -v "${FFI_DIR}/linux/aarch64/:/build/binaries" -v "${SRC_DIR}:/build/binding" -v "$(pwd)/dist:/build/dist" -e PLAT_NAME="manylinux_2_17_aarch64" wheel-builder
+
+# Build macos wheels
+docker run --rm -v "${FFI_DIR}/apple/macos/x86_64/:/build/binaries" -v "${SRC_DIR}:/build/binding" -v "$(pwd)/dist:/build/dist" -e PLAT_NAME="macosx_11_0_x86_64" wheel-builder
+docker run --rm -v "${FFI_DIR}/apple/macos/aarch64/:/build/binaries" -v "${SRC_DIR}:/build/binding" -v "$(pwd)/dist:/build/dist" -e PLAT_NAME="macosx_11_0_arm64" wheel-builder
+
+# Build win wheels
+docker run --rm -v "${FFI_DIR}/win/x86/:/build/binaries" -v "${SRC_DIR}:/build/binding" -v "$(pwd)/dist:/build/dist" -e PLAT_NAME="win32" wheel-builder
+docker run --rm -v "${FFI_DIR}/win/x86_64/:/build/binaries" -v "${SRC_DIR}:/build/binding" -v "$(pwd)/dist:/build/dist" -e PLAT_NAME="win_amd64" wheel-builder
+docker run --rm -v "${FFI_DIR}/win/aarch64/:/build/binaries" -v "${SRC_DIR}:/build/binding" -v "$(pwd)/dist:/build/dist" -e PLAT_NAME="win_arm64" wheel-builder

--- a/python/buildwheel.sh
+++ b/python/buildwheel.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Build a wheel. This script is used from the Dockerfile!
+
+set -exuo pipefail
+
+# Check if required arguments are provided
+if [ -z "$PLAT_NAME" ]; then
+    echo "ERROR: PLAT_NAME environment variable is required"
+    exit 1
+fi
+
+echo "Building wheel for platform: $PLAT_NAME"
+
+# Copy binaries to python directory if they exist
+if [ "$(ls -A /build/binaries)" ]; then
+    cp -r /build/binaries/* /build/python/src/nostr-sdk/
+    echo "Copied binaries to Python package directory"
+else
+    echo "No binaries found in /build/binaries"
+    exit 1
+fi
+
+# Copy generated binding file to the correct location if it exists
+if [ -f "/build/binding/nostr_sdk.py" ]; then
+    # Make sure the target directory exists
+    cp /build/binding/nostr_sdk.py /build/python/src/nostr-sdk/
+    echo "Copied binding file (nostr_sdk.py) to src/nostr-sdk/ directory"
+else
+    echo "WARNING: Binding file (nostr_sdk.py) not found in /build/binding"
+    exit 1
+fi
+
+
+# Enter Python package directory
+cd /build/python
+
+# Build the wheel with Python 3.9 ABI3 compatibility
+python setup.py bdist_wheel --plat-name "$PLAT_NAME" --python-tag cp39.abi3
+
+# Copy wheel to the output directory
+cp dist/*.whl /build/dist/

--- a/python/setup.py
+++ b/python/setup.py
@@ -22,4 +22,10 @@ setup(
     # This is required to ensure the library name includes the python version, abi, and platform tags
     # See issue #350 for more information
     has_ext_modules=lambda: True,
+    # This enables abi3 compatibility
+    options={
+        "bdist_wheel": {
+            "py_limited_api": "cp39",  # Support Python 3.9+
+        }
+    },
 )


### PR DESCRIPTION
Build python wheels locally using cp39-abi3. This should allow to publish a single wheel for every python versions (3.9+).

Add `i686-unknown-linux-gnu`, `i686-pc-windows-msvc` and `aarch64-pc-windows-msvc` support for Python Wheels.