### PR TITLE
Expose `NostrParser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
 - Set default params for `EventDeletionRequest` and `Contact`
 - Update the android libraries to use 16KB page alignment (https://github.com/rust-nostr/nostr-sdk-ffi/pull/18)
 
+### Added
+
+- Expose `NostrParser` (https://github.com/rust-nostr/nostr-sdk-ffi/pull/13)
+
 ## v0.42.1 - 2025/05/26
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logger;
 pub mod negentropy;
 pub mod notifications;
 pub mod nwc;
+pub mod parser;
 pub mod policy;
 pub mod protocol;
 pub mod relay;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2022-2023 Yuki Kishimoto
+// Copyright (c) 2023-2025 Rust Nostr Developers
+// Distributed under the MIT software license
+
+use nostr::parser::{self, Token};
+use uniffi::{Enum, Object};
+
+use crate::protocol::nips::nip21::Nip21Enum;
+
+#[derive(Enum)]
+pub enum NostrParserToken {
+    /// Nostr URI
+    ///
+    /// <https://github.com/nostr-protocol/nips/blob/master/21.md>
+    Nostr(Nip21Enum),
+    /// Url
+    Url(String),
+    /// Hashtag
+    Hashtag(String),
+    /// Other text
+    ///
+    /// Spaces at the beginning or end of a text are parsed as [`Token::Whitespace`].
+    Text(String),
+    /// Line break
+    LineBreak,
+    /// A whitespace
+    Whitespace,
+}
+
+impl<'a> From<Token<'a>> for NostrParserToken {
+    fn from(token: Token<'a>) -> Self {
+        match token {
+            Token::Nostr(uri) => Self::Nostr(uri.into()),
+            Token::Url(url) => Self::Url(url.to_string()),
+            Token::Hashtag(hashtag) => Self::Hashtag(hashtag.to_string()),
+            Token::Text(text) => Self::Text(text.to_string()),
+            Token::LineBreak => Self::LineBreak,
+            Token::Whitespace => Self::Whitespace,
+        }
+    }
+}
+
+/// Nostr parser
+#[derive(Object)]
+pub struct NostrParser {
+    inner: parser::NostrParser,
+}
+
+#[uniffi::export]
+impl NostrParser {
+    /// Construct a new nostr parser
+    ///
+    /// It's suggested to construct this once and reuse it, to avoid regex re-compilation.
+    #[uniffi::constructor]
+    pub fn new() -> Self {
+        Self {
+            inner: parser::NostrParser::new(),
+        }
+    }
+
+    /// Parse text into tokens
+    pub fn parse(&self, text: &str) -> Vec<NostrParserToken> {
+        self.inner.parse(text).map(NostrParserToken::from).collect()
+    }
+}


### PR DESCRIPTION
Before merge this, the `NostrParser` must be reworked (PR https://github.com/rust-nostr/nostr/pull/899) to avoid huge increase of the binaries size (at the moment the increase is between 500kb and 1MB per-binary), mainly due to the `regex` dep. Removing the `regex` dep, the binaries size should remain the same.

Closes https://github.com/rust-nostr/nostr-sdk-ffi/issues/12