### PR TITLE
Expose arithmetic operations on `Timestamp` with `Duration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Added
 
 - Expose `NostrParser` (https://github.com/rust-nostr/nostr-sdk-ffi/pull/13)
+- Expose arithmetic operations on `Timestamp` with `Duration` (https://github.com/rust-nostr/nostr-sdk-ffi/pull/25)
 
 ## v0.42.1 - 2025/05/26
 

--- a/src/protocol/types/time.rs
+++ b/src/protocol/types/time.rs
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license
 
 use std::ops::Deref;
+use std::time::Duration;
 
 use uniffi::Object;
 
@@ -40,6 +41,26 @@ impl Timestamp {
     pub fn from_secs(secs: u64) -> Self {
         Self {
             inner: nostr::Timestamp::from_secs(secs),
+        }
+    }
+
+    /// Add duration to timestamp
+    ///
+    /// This sums the duration to the current timestamp and returns a new timestamp.
+    #[inline]
+    pub fn add_duration(&self, duration: Duration) -> Self {
+        Self {
+            inner: self.inner + duration,
+        }
+    }
+
+    /// Subtract duration from timestamp
+    ///
+    /// This subtracts the duration from the current timestamp and returns a new timestamp.
+    #[inline]
+    pub fn sub_duration(&self, duration: Duration) -> Self {
+        Self {
+            inner: self.inner - duration,
         }
     }
 


### PR DESCRIPTION
Add `Timestamp::add_duration` and `Timestamp::sub_duration`.

Closes https://github.com/rust-nostr/nostr-sdk-ffi/issues/22