### PR TITLE
Replace `uniffi` crates with custom branch to use `kotlin.time` instead of `java.time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5249,8 +5249,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.29.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b39ef1acbe1467d5d210f274fae344cb6f8766339330cb4c9688752899bf6b"
+source = "git+https://github.com/yukibtc/uniffi-rs?rev=0ae01f1032217b4d961b7ae4cbdec63aa5373da7#0ae01f1032217b4d961b7ae4cbdec63aa5373da7"
 dependencies = [
  "anyhow",
  "askama",
@@ -5266,8 +5265,8 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml 0.5.11",
- "uniffi_internal_macros",
- "uniffi_meta",
+ "uniffi_internal_macros 0.29.4",
+ "uniffi_meta 0.29.4 (git+https://github.com/yukibtc/uniffi-rs?rev=0ae01f1032217b4d961b7ae4cbdec63aa5373da7)",
  "uniffi_pipeline",
  "uniffi_udl",
 ]
@@ -5288,8 +5287,20 @@ dependencies = [
 [[package]]
 name = "uniffi_internal_macros"
 version = "0.29.4"
+source = "git+https://github.com/yukibtc/uniffi-rs?rev=0ae01f1032217b4d961b7ae4cbdec63aa5373da7#0ae01f1032217b4d961b7ae4cbdec63aa5373da7"
+dependencies = [
+ "anyhow",
+ "indexmap 2.12.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f4f224becf14885c10e6e400b95cc4d1985738140cb194ccc2044563f8a56b"
+checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -5312,7 +5323,7 @@ dependencies = [
  "serde",
  "syn 2.0.100",
  "toml 0.5.11",
- "uniffi_meta",
+ "uniffi_meta 0.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5323,32 +5334,41 @@ checksum = "10f817868a3b171bb7bf259e882138d104deafde65684689b4694c846d322491"
 dependencies = [
  "anyhow",
  "siphasher 0.3.11",
- "uniffi_internal_macros",
+ "uniffi_internal_macros 0.29.5",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.29.4"
+source = "git+https://github.com/yukibtc/uniffi-rs?rev=0ae01f1032217b4d961b7ae4cbdec63aa5373da7#0ae01f1032217b4d961b7ae4cbdec63aa5373da7"
+dependencies = [
+ "anyhow",
+ "siphasher 0.3.11",
+ "uniffi_internal_macros 0.29.4",
  "uniffi_pipeline",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
 version = "0.29.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b147e133ad7824e32426b90bc41fda584363563f2ba747f590eca1fd6fd14e6"
+source = "git+https://github.com/yukibtc/uniffi-rs?rev=0ae01f1032217b4d961b7ae4cbdec63aa5373da7#0ae01f1032217b4d961b7ae4cbdec63aa5373da7"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.12.0",
  "tempfile",
- "uniffi_internal_macros",
+ "uniffi_internal_macros 0.29.4",
 ]
 
 [[package]]
 name = "uniffi_udl"
 version = "0.29.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caed654fb73da5abbc7a7e9c741532284532ba4762d6fe5071372df22a41730a"
+source = "git+https://github.com/yukibtc/uniffi-rs?rev=0ae01f1032217b4d961b7ae4cbdec63aa5373da7#0ae01f1032217b4d961b7ae4cbdec63aa5373da7"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta",
+ "uniffi_meta 0.29.4 (git+https://github.com/yukibtc/uniffi-rs?rev=0ae01f1032217b4d961b7ae4cbdec63aa5373da7)",
  "weedle2",
 ]
 
@@ -5572,8 +5592,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/yukibtc/uniffi-rs?rev=0ae01f1032217b4d961b7ae4cbdec63aa5373da7#0ae01f1032217b4d961b7ae4cbdec63aa5373da7"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,8 @@ paranoid-android = "0.2"
 [patch.crates-io]
 # Patch that uses bitcoin_hashes v0.14
 bip39 = { git = "https://github.com/yukibtc/rust-bip39", branch = "v2.1.0+hashes-v0.14" }
+# Patch for replacing java.time with kotlin.time
+# Issue: https://github.com/rust-nostr/nostr-sdk-ffi/issues/66
+uniffi_bindgen = { git = "https://github.com/yukibtc/uniffi-rs", rev = "0ae01f1032217b4d961b7ae4cbdec63aa5373da7" }
+uniffi_pipeline = { git = "https://github.com/yukibtc/uniffi-rs", rev = "0ae01f1032217b4d961b7ae4cbdec63aa5373da7" }
+uniffi_internal_macros = { git = "https://github.com/yukibtc/uniffi-rs", rev = "0ae01f1032217b4d961b7ae4cbdec63aa5373da7" }


### PR DESCRIPTION
Fixes https://github.com/rust-nostr/nostr-sdk-ffi/issues/66
